### PR TITLE
Task 047 apply spring security

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 	testImplementation "org.testcontainers:testcontainers:1.17.6"

--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -21,17 +21,27 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	testImplementation 'org.projectlombok:lombok:1.18.26'
+
 	implementation 'com.github.docker-java:docker-java:3.3.0'
 	implementation 'com.github.docker-java:docker-java-transport-httpclient5:3.3.0'
-	testImplementation "org.testcontainers:testcontainers:1.17.6"
-	testImplementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+	implementation 'com.auth0:java-jwt:4.4.0'
+
+	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
+
+	runtimeOnly 'com.h2database:h2'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
+	testImplementation "org.testcontainers:testcontainers:1.17.6"
+
+	testImplementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {

--- a/api-server/src/main/java/org/gantry/apiserver/ApiServerApplication.java
+++ b/api-server/src/main/java/org/gantry/apiserver/ApiServerApplication.java
@@ -2,6 +2,7 @@ package org.gantry.apiserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
 public class ApiServerApplication {

--- a/api-server/src/main/java/org/gantry/apiserver/config/DockerConfiguration.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/DockerConfiguration.java
@@ -11,15 +11,15 @@ import org.springframework.context.annotation.Configuration;
 import java.time.Duration;
 
 @Configuration
-@ConfigurationProperties(prefix = "docker")
+@ConfigurationProperties(prefix = "gantry.docker")
 public class DockerConfiguration {
     @Setter
-    private String dockerHost;
+    private String host;
 
     @Bean
     DockerClient dockerClientConfig(){
         DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
-                .withDockerHost(dockerHost)
+                .withDockerHost(host)
                 .build();
 
         ApacheDockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/InvalidTokenException.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package org.gantry.apiserver.config.security;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/JWTAuthenticationFilter.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/JWTAuthenticationFilter.java
@@ -1,0 +1,78 @@
+package org.gantry.apiserver.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.SneakyThrows;
+import org.gantry.apiserver.domain.User;
+import org.gantry.apiserver.web.dto.ErrorResponse;
+import org.gantry.apiserver.web.dto.UserDto;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.gantry.apiserver.config.security.JWTProperties.AUTHZ_HEADER;
+import static org.gantry.apiserver.config.security.JWTProperties.BEARER_PREFIX;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, ObjectMapper objectMapper) {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+        this.objectMapper = objectMapper;
+        setFilterProcessesUrl("/auth/token");
+    }
+
+    @SneakyThrows(IOException.class)
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        User user = objectMapper.readValue(request.getInputStream(), User.class);
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(user.getUsername(), user.getPassword(), user.getAuthorities());
+        return authenticationManager.authenticate(token);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException {
+        User principal = (User) authResult.getPrincipal();
+        String token =  jwtUtil.create(principal);
+        response.addHeader(AUTHZ_HEADER, BEARER_PREFIX + token);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        OutputStream responseStream = response.getOutputStream();
+        UserDto dto = UserDto.from(principal);
+        dto.setAccessToken(token);
+        objectMapper.writeValue(responseStream, dto);
+        responseStream.flush();
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        exception.printStackTrace();
+        response.setStatus(SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        OutputStream responseStream = response.getOutputStream();
+        objectMapper.writeValue(responseStream, ErrorResponse.builder()
+                .uri(request.getRequestURI())
+                .status(UNAUTHORIZED)
+                .message("Authentication Failed")
+                .detail(exception.getMessage())
+                .build());
+        responseStream.flush();
+    }
+}

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/JWTAuthorizationFilter.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/JWTAuthorizationFilter.java
@@ -1,0 +1,76 @@
+package org.gantry.apiserver.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.gantry.apiserver.domain.User;
+import org.gantry.apiserver.web.dto.ErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static org.gantry.apiserver.config.security.JWTProperties.AUTHZ_HEADER;
+import static org.gantry.apiserver.config.security.JWTProperties.BEARER_PREFIX;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
+
+    private final JWTUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    public JWTAuthorizationFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, ObjectMapper objectMapper) {
+        super(authenticationManager);
+        this.jwtUtil = jwtUtil;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = getTokenFrom(request);
+        if (!jwtUtil.verify(token)) {
+            throw new InvalidTokenException("Token was not valid");
+        }
+
+        User user = jwtUtil.decode(token);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(user.getUsername(), null, user.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        chain.doFilter(request, response);
+    }
+
+    private String getTokenFrom(HttpServletRequest request) {
+        String authHeader = request.getHeader(AUTHZ_HEADER);
+        if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        return  authHeader.substring(BEARER_PREFIX.length());
+    }
+
+
+
+    @Override
+    protected void onUnsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+        exception.printStackTrace();
+        response.setStatus(SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        OutputStream responseStream = response.getOutputStream();
+
+        objectMapper.writeValue(responseStream, ErrorResponse.builder()
+                .uri(request.getRequestURI())
+                .status(UNAUTHORIZED)
+                .message("Access Denied")
+                .detail(exception.getMessage())
+                .build());
+        responseStream.flush();
+    }
+}
+

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/JWTProperties.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/JWTProperties.java
@@ -1,0 +1,30 @@
+package org.gantry.apiserver.config.security;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "gantry.jwt")
+public class JWTProperties {
+    public static String AUTHZ_HEADER = "Authorization";
+    public static String REFRESH_HEADER = "refresh-token";
+    public static String BEARER_PREFIX = "Bearer ";
+
+    private String secret = "default-secret";
+
+    private boolean secretGenerating = true;
+
+    private String generatedSecretPostfix = LocalDateTime.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+//    private String generatedSecretPostfix = UUID.randomUUID().toString();
+
+    private long expirationSecond = 60*60L;
+
+//    public String getSecret() {
+//        return secretGenerating ? secret + "-" + generatedSecretPostfix : secret;
+//    }
+}

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/JWTUtil.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/JWTUtil.java
@@ -1,0 +1,72 @@
+package org.gantry.apiserver.config.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import lombok.RequiredArgsConstructor;
+import org.gantry.apiserver.domain.Authority;
+import org.gantry.apiserver.domain.User;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Component
+public class JWTUtil {
+
+    private final JWTProperties properties;
+
+    public String create(User user) {
+        JWTCreator.Builder builder = JWT.create()
+                .withIssuer("gantry-server")
+                .withSubject("user-authentication-token")
+                .withIssuedAt(Instant.now())
+                .withExpiresAt(Instant.now().plusSeconds(properties.getExpirationSecond()))
+                .withClaim("id", user.getId())
+                .withClaim("username", user.getUsername())
+                .withClaim("email", user.getEmail());
+        if (user.getAuthority() != null) {
+            builder.withClaim("authority", user.getAuthority().toString());
+        }
+        return builder.sign(getAlgorithm());
+    }
+
+    private Algorithm getAlgorithm() {
+        return Algorithm.HMAC512(properties.getSecret());
+    }
+
+    public User decode(String token) {
+        DecodedJWT decoded = JWT.decode(token);
+        User user = new User();
+
+        Claim id = decoded.getClaim("id");
+        if (!id.isMissing()) user.setId(id.asLong());
+
+        Claim username = decoded.getClaim("username");
+        if (!username.isMissing()) user.setUsername(username.asString());
+
+        Claim email = decoded.getClaim("email");
+        if (!email.isMissing()) user.setEmail(email.asString());
+
+        Claim authority = decoded.getClaim("authority");
+        if (!authority.isMissing() && Arrays.asList(Authority.values()).contains(authority)) {
+            user.setAuthority(Authority.valueOf(authority.asString()));
+        }
+
+        return user;
+    }
+
+    public boolean verify(String token) {
+        try {
+            JWT.require(getAlgorithm()).build().verify(token);
+            return true;
+
+        } catch(JWTVerificationException e) {
+            return false;
+        }
+    }
+}

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/SecurityConfiguration.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/SecurityConfiguration.java
@@ -1,0 +1,162 @@
+package org.gantry.apiserver.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.catalina.connector.ResponseFacade;
+import org.gantry.apiserver.web.dto.ErrorResponse;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.io.OutputStream;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+
+@Profile("!simple-security")
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true)
+public class SecurityConfiguration {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.addAllowedOrigin("*");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http, PasswordEncoder passwordEncoder,
+                                                       UserDetailsService userDetailsService) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class)
+                .userDetailsService(userDetailsService)
+                .passwordEncoder(passwordEncoder)
+                .and()
+                .build();
+    }
+
+    @Bean
+    public AuthenticationFailureHandler authenticationFailureHandler(ObjectMapper objectMapper) {
+        return (request, response, exception) -> {
+            exception.printStackTrace();
+            response.setStatus(SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+            OutputStream responseStream = response.getOutputStream();
+            objectMapper.writeValue(responseStream, ErrorResponse.builder()
+                    .uri(request.getRequestURI())
+                    .status(UNAUTHORIZED)
+                    .message("Authentication Failed")
+                    .detail(exception.getMessage())
+                    .build());
+            responseStream.flush();
+        };
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint(ObjectMapper objectMapper) {
+        return (request, response, exception) -> {
+            exception.printStackTrace();
+            response.setStatus(SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+            OutputStream responseStream = response.getOutputStream();
+            objectMapper.writeValue(responseStream, ErrorResponse.builder()
+                    .uri(request.getRequestURI())
+                    .status(UNAUTHORIZED)
+                    .message("Authentication Failed")
+                    .detail(exception.getMessage())
+                    .build());
+            responseStream.flush();
+        };
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler(ObjectMapper objectMapper) {
+        return (request, response, exception) -> {
+            exception.printStackTrace();
+            response.setStatus(SC_FORBIDDEN);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            OutputStream responseStream = response.getOutputStream();
+
+            objectMapper.writeValue(responseStream, ErrorResponse.builder()
+                    .uri(request.getRequestURI())
+                    .status(UNAUTHORIZED)
+                    .message("Access Denied")
+                    .detail(exception.getMessage())
+                    .build());
+            responseStream.flush();
+        };
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "health")
+                .requestMatchers(PathRequest.toH2Console())
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager,
+                                           JWTUtil jwtUtil, ObjectMapper objectMapper) throws Exception {
+        JWTAuthenticationFilter jwtAuthnFilter = new JWTAuthenticationFilter(authenticationManager, jwtUtil, objectMapper);
+        JWTAuthorizationFilter jwtAuthzFilter = new JWTAuthorizationFilter(authenticationManager, jwtUtil, objectMapper);
+
+        http.csrf().disable()
+            .httpBasic().disable()
+            .formLogin().disable()
+            .addFilter(jwtAuthnFilter)
+            .addFilter(jwtAuthzFilter)
+            .cors()
+                .and()
+            .authorizeHttpRequests()
+                .requestMatchers("/admin/**").hasRole("ADMIN")
+                .requestMatchers("/api/v1/**").hasAnyRole("ADMIN", "USER")
+                .requestMatchers("/auth/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+            .exceptionHandling()
+                .authenticationEntryPoint(authenticationEntryPoint(objectMapper))
+                .accessDeniedHandler(accessDeniedHandler(objectMapper))
+                .and()
+            .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        ;
+
+        return http.build();
+    }
+
+}

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/SecurityConfiguration.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/SecurityConfiguration.java
@@ -123,7 +123,7 @@ public class SecurityConfiguration {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring()
-                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "health")
+                .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/health")
                 .requestMatchers(PathRequest.toH2Console())
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
@@ -146,6 +146,7 @@ public class SecurityConfiguration {
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/**").hasAnyRole("ADMIN", "USER")
                 .requestMatchers("/auth/**").permitAll()
+                .requestMatchers("/health").permitAll()
                 .anyRequest().authenticated()
                 .and()
             .exceptionHandling()

--- a/api-server/src/main/java/org/gantry/apiserver/config/security/SimpleSecurityConfiguration.java
+++ b/api-server/src/main/java/org/gantry/apiserver/config/security/SimpleSecurityConfiguration.java
@@ -1,0 +1,21 @@
+package org.gantry.apiserver.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Profile("simple-security")
+@Configuration
+@EnableWebSecurity
+public class SimpleSecurityConfiguration {
+
+    @Bean
+    public PasswordEncoder noOpPasswordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
+    }
+
+}

--- a/api-server/src/main/java/org/gantry/apiserver/domain/Authority.java
+++ b/api-server/src/main/java/org/gantry/apiserver/domain/Authority.java
@@ -1,0 +1,24 @@
+package org.gantry.apiserver.domain;
+
+import org.springframework.security.core.GrantedAuthority;
+
+public enum Authority implements GrantedAuthority {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String authority;
+
+    Authority(String authority) {
+        this.authority = authority;
+    }
+
+    @Override
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public String toString() {
+        return this.authority;
+    }
+}

--- a/api-server/src/main/java/org/gantry/apiserver/domain/User.java
+++ b/api-server/src/main/java/org/gantry/apiserver/domain/User.java
@@ -1,0 +1,60 @@
+package org.gantry.apiserver.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Table(name = "USERS")
+@Entity
+public class User implements UserDetails {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private long id;
+    private String username;
+    private String email;
+
+    private String password;
+    private boolean enabled;
+
+    @Enumerated(EnumType.STRING)
+    private Authority authority;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authority == null ? List.of() : List.of(authority);
+    };
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return enabled;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return enabled;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return enabled;
+    }
+
+}

--- a/api-server/src/main/java/org/gantry/apiserver/persistence/UserRepository.java
+++ b/api-server/src/main/java/org/gantry/apiserver/persistence/UserRepository.java
@@ -1,0 +1,10 @@
+package org.gantry.apiserver.persistence;
+
+import org.gantry.apiserver.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, String> {
+    Optional<User> findByUsername(String username);
+}

--- a/api-server/src/main/java/org/gantry/apiserver/service/UserService.java
+++ b/api-server/src/main/java/org/gantry/apiserver/service/UserService.java
@@ -1,0 +1,21 @@
+package org.gantry.apiserver.service;
+
+import lombok.RequiredArgsConstructor;
+import org.gantry.apiserver.persistence.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository repository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return repository.findByUsername(username).orElseThrow(
+                () -> new UsernameNotFoundException("%s is not found.".formatted(username)));
+    }
+}

--- a/api-server/src/main/java/org/gantry/apiserver/web/ApplicationController.java
+++ b/api-server/src/main/java/org/gantry/apiserver/web/ApplicationController.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @CrossOrigin(origins = "http://localhost:3000")
-@RequestMapping("/applications")
+@RequestMapping("/api/v1/applications")
 @RestController
 @CrossOrigin(origins = "http://localhost:3000")
 public class ApplicationController {

--- a/api-server/src/main/java/org/gantry/apiserver/web/ApplicationController.java
+++ b/api-server/src/main/java/org/gantry/apiserver/web/ApplicationController.java
@@ -13,10 +13,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:3000")
-@RequestMapping("/api/v1/applications")
 @RestController
-@CrossOrigin(origins = "http://localhost:3000")
+@RequestMapping("/api/v1/applications")
 public class ApplicationController {
 
     private final ApplicationService service;

--- a/api-server/src/main/java/org/gantry/apiserver/web/ContainerController.java
+++ b/api-server/src/main/java/org/gantry/apiserver/web/ContainerController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("/containers")
+@RequestMapping("/api/v1/containers")
 @RestController
 public class ContainerController {
 

--- a/api-server/src/main/java/org/gantry/apiserver/web/dto/UserDto.java
+++ b/api-server/src/main/java/org/gantry/apiserver/web/dto/UserDto.java
@@ -1,0 +1,33 @@
+package org.gantry.apiserver.web.dto;
+
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Builder;
+import lombok.Data;
+import lombok.ToString;
+import org.gantry.apiserver.domain.Authority;
+import org.gantry.apiserver.domain.Container;
+import org.gantry.apiserver.domain.ContainerStatus;
+import org.gantry.apiserver.domain.User;
+
+@Builder
+@Data
+@ToString
+public class UserDto {
+    private long id;
+    private String username;
+    private String email;
+    private boolean enabled;
+    private Authority authority;
+    private String accessToken;
+
+    public static UserDto from(User user) {
+        return UserDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .enabled(user.isEnabled())
+                .authority(user.getAuthority())
+                .build();
+    }
+}

--- a/api-server/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/api-server/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,13 @@
+{
+  "groups": [{
+    "name": "gantry.jwt",
+    "type": "org.gantry.apiserver.config.security.JWTProperties"
+  }],
+  "properties": [{
+    "name": "gantry.jwt.secret",
+    "type": "java.lang.String"
+  }, {
+    "name": "gantry.jwt.expiration-second",
+    "type": "java.lang.Long"
+  }]
+}

--- a/api-server/src/main/resources/application.properties
+++ b/api-server/src/main/resources/application.properties
@@ -1,18 +1,25 @@
 server.port=8080
 
-docker.dockerhost = tcp://localhost:2375
+gantry.docker.host = tcp://localhost:2375
+gantry.jwt.secret=xyzsjkldjf273819
+gantry.jwt.expiriation-second=3600
 
 
 
-## Environments for Development
+### Environments for Development
 
-### server.error.include-stacktrace=ALWAYS
+# server.error.include-stacktrace=ALWAYS
+
+
 
 ### Swagger options
 #springdoc.swagger-ui.path=/swagger-ui.html
-#springdoc.swagger-ui.enabled=false
-#springdoc.api-docs.enabled=false
+#springdoc.swagger-ui.enabled=false # production ??? false ??
+#springdoc.api-docs.enabled=false # production ??? false ??
 springdoc.swagger-ui.operationsSorter=method
+springdoc.show-login-endpoint=true
+
+
 
 ### SQL and Parameters for logging
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
@@ -30,10 +37,15 @@ spring.h2.console.enabled=true
 #spring.h2.console.settings.trace=false
 #spring.h2.console.settings.web-allow-others=false
 
+
+
 ### data initialization
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.data-locations=classpath:init/data.sql
 #spring.sql.init.schema-locations=classpath:schema.sql
+#spring.h2.console.path=/h2-console
+
+logging.level.org.springframework.security=DEBUG
 
 
 ## Environments for Production

--- a/api-server/src/main/resources/init/data.sql
+++ b/api-server/src/main/resources/init/data.sql
@@ -1,10 +1,10 @@
 insert into APPLICATION (application_id, title, image, platform_type, created_date, modified_date)
-values (1, 'mysql', 'mysql/mysql:latest', 'DOCKER', now()-1, now()-1)
-     , (2, 'postgresql', 'postgresql/postgresql:latest', 'DOCKER', now(), now()) ;
+values (9000001, 'mysql', 'mysql/mysql:latest', 'DOCKER', now()-1, now()-1)
+     , (9000002, 'postgresql', 'postgresql/postgresql:latest', 'DOCKER', now(), now()) ;
 
 insert into CONTAINER (container_id, application_id, status, created_date, modified_date)
-values ('c001', 1, 'RUNNING', now(), now())
-     , ('c022', 2, 'RUNNING', now(), now());
+values ('cxxxxx001', 9000001, 'RUNNING', now(), now())
+     , ('cxxxxx022', 9000002, 'RUNNING', now(), now());
 
 insert into users (id, email, enabled, password, username, authority)
 values (9999999999, 'admin@admin.com', true, 'admin', 'admin', 'ADMIN')

--- a/api-server/src/main/resources/init/data.sql
+++ b/api-server/src/main/resources/init/data.sql
@@ -1,6 +1,11 @@
 insert into APPLICATION (application_id, title, image, platform_type, created_date, modified_date)
 values (1, 'mysql', 'mysql/mysql:latest', 'DOCKER', now()-1, now()-1)
      , (2, 'postgresql', 'postgresql/postgresql:latest', 'DOCKER', now(), now()) ;
+
 insert into CONTAINER (container_id, application_id, status, created_date, modified_date)
-    values ('c001', 1, 'RUNNING', now(), now())
-         , ('c022', 2, 'RUNNING', now(), now());
+values ('c001', 1, 'RUNNING', now(), now())
+     , ('c022', 2, 'RUNNING', now(), now());
+
+insert into users (id, email, enabled, password, username, authority)
+values (9999999999, 'admin@admin.com', true, 'admin', 'admin', 'ADMIN')
+     , (8888888888, 'user@user.com', true, '$2a$10$eumZRPGbixwv5JZQM6nsWuoekrXgXR43IQ4tU8COzSQ9phevy36CG', 'user', 'USER');

--- a/api-server/src/test/java/org/gantry/apiserver/config/security/JWTUtilTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/config/security/JWTUtilTest.java
@@ -1,4 +1,4 @@
-package org.gantry.apiserver.util.jwt;
+package org.gantry.apiserver.config.security;
 
 import org.gantry.apiserver.config.security.JWTUtil;
 import org.gantry.apiserver.config.security.JWTProperties;

--- a/api-server/src/test/java/org/gantry/apiserver/persistence/ApplicationRepositoryTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/persistence/ApplicationRepositoryTest.java
@@ -1,6 +1,7 @@
 package org.gantry.apiserver.persistence;
 
 import org.gantry.apiserver.domain.Application;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,11 @@ class ApplicationRepositoryTest {
 
     @Autowired
     private ApplicationRepository repository;
+
+    @BeforeEach
+    void clean() {
+        repository.deleteAll();
+    }
 
     @Test
     void findAll() {

--- a/api-server/src/test/java/org/gantry/apiserver/util/jwt/JWTUtilTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/util/jwt/JWTUtilTest.java
@@ -1,0 +1,58 @@
+package org.gantry.apiserver.util.jwt;
+
+import org.gantry.apiserver.config.security.JWTUtil;
+import org.gantry.apiserver.config.security.JWTProperties;
+import org.gantry.apiserver.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(JWTProperties.class)
+@ExtendWith(SpringExtension.class)
+public class JWTUtilTest {
+    @Autowired
+    private JWTProperties jwtProperties;
+
+    @Test
+    void test_create_token() {
+        User user = User.builder().username("user001").build();
+
+        JWTUtil jwt = new JWTUtil(jwtProperties);
+        String token = jwt.create(user);
+        User decoded = jwt.decode(token);
+
+        assertThat(decoded.getUsername()).isEqualTo("user001");
+    }
+
+    @Test
+    void test_verity() throws InterruptedException {
+        User user = User.builder().username("user001").build();
+
+        jwtProperties.setExpirationSecond(2);
+        JWTUtil jwt = new JWTUtil(jwtProperties);
+        String token = jwt.create(user);
+        boolean isValidBefore = jwt.verify(token);
+
+        Thread.sleep(2000);
+        boolean isValidAfter = jwt.verify(token);
+
+        assertThat(isValidBefore).isTrue();
+        assertThat(isValidAfter).isFalse();
+    }
+
+    @Test
+    void test_verity_with_blank_string() {
+        JWTUtil jwt = new JWTUtil(jwtProperties);
+        boolean withEmptyString = jwt.verify("");
+        boolean withWhitespace = jwt.verify(" ");
+        boolean withNull = jwt.verify(null);
+
+        assertThat(withEmptyString).isFalse();
+        assertThat(withWhitespace).isFalse();
+        assertThat(withNull).isFalse();
+    }
+}

--- a/api-server/src/test/java/org/gantry/apiserver/web/ApplicationControllerTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/web/ApplicationControllerTest.java
@@ -46,7 +46,7 @@ class ApplicationControllerTest {
         testContainer.setApplication(testApplication);
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void list() throws Exception {
         given(service.findAll()).willReturn(List.of(testApplication));
@@ -57,7 +57,7 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("[0].title").value("test"));
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void getOne() throws Exception {
         given(service.findById(anyLong())).willReturn(Optional.of(testApplication));
@@ -68,7 +68,7 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("title").value("test"));
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void execute() throws Exception {
         given(service.execute(anyLong())).willReturn(testContainer);

--- a/api-server/src/test/java/org/gantry/apiserver/web/ApplicationControllerTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/web/ApplicationControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -19,6 +20,8 @@ import java.util.Optional;
 import static org.gantry.apiserver.domain.ContainerStatus.RUNNING;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -43,31 +46,34 @@ class ApplicationControllerTest {
         testContainer.setApplication(testApplication);
     }
 
+    @WithMockUser(username="user")
     @Test
     void list() throws Exception {
         given(service.findAll()).willReturn(List.of(testApplication));
 
-        mockMvc.perform(get("/applications"))
+        mockMvc.perform(get("/api/v1/applications"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("[0].title").value("test"));
     }
 
+    @WithMockUser(username="user")
     @Test
     void getOne() throws Exception {
         given(service.findById(anyLong())).willReturn(Optional.of(testApplication));
 
-        mockMvc.perform(get("/applications/1"))
+        mockMvc.perform(get("/api/v1/applications/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("title").value("test"));
     }
 
+    @WithMockUser(username="user")
     @Test
     void execute() throws Exception {
         given(service.execute(anyLong())).willReturn(testContainer);
 
-        mockMvc.perform(post("/applications/1/execute"))
+        mockMvc.perform(post("/api/v1/applications/1/execute").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("id").value("test0001"));

--- a/api-server/src/test/java/org/gantry/apiserver/web/ContainerControllerTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/web/ContainerControllerTest.java
@@ -52,7 +52,7 @@ class ContainerControllerTest {
         testContainer.setApplication(testApplication);
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void stop() throws Exception {
         testContainer.setStatus(PAUSED);
@@ -66,7 +66,7 @@ class ContainerControllerTest {
     }
 
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void restart() throws Exception {
         testContainer.setStatus(RESTARTING);
@@ -79,7 +79,7 @@ class ContainerControllerTest {
                 .andExpect(jsonPath("status").value("RESTARTING"));
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void remove() throws Exception {
         testContainer.setStatus(REMOVING);
@@ -92,7 +92,7 @@ class ContainerControllerTest {
                 .andExpect(jsonPath("status").value("REMOVING"));
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void getStatus() throws Exception {
         given(service.findById(anyString())).willReturn(testContainer);
@@ -104,7 +104,7 @@ class ContainerControllerTest {
                 .andExpect(jsonPath("status").value("RUNNING"));
     }
 
-    @WithMockUser(username="user")
+    @WithMockUser
     @Test
     void list() throws Exception {
         given(service.findRunningContainers()).willReturn(List.of(testContainer, testContainer));

--- a/api-server/src/test/java/org/gantry/apiserver/web/ContainerControllerTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/web/ContainerControllerTest.java
@@ -1,5 +1,6 @@
 package org.gantry.apiserver.web;
 
+import lombok.With;
 import org.gantry.apiserver.domain.Application;
 import org.gantry.apiserver.domain.Container;
 import org.gantry.apiserver.service.ContainerService;
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -18,6 +20,7 @@ import java.util.List;
 import static org.gantry.apiserver.domain.ContainerStatus.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -49,12 +52,13 @@ class ContainerControllerTest {
         testContainer.setApplication(testApplication);
     }
 
+    @WithMockUser(username="user")
     @Test
     void stop() throws Exception {
         testContainer.setStatus(PAUSED);
         given(service.stop(anyString())).willReturn(testContainer);
 
-        mockMvc.perform(post("/containers/testid0001/stop"))
+        mockMvc.perform(post("/api/v1/containers/testid0001/stop").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("id").value("testid0001"))
@@ -62,46 +66,50 @@ class ContainerControllerTest {
     }
 
 
+    @WithMockUser(username="user")
     @Test
     void restart() throws Exception {
         testContainer.setStatus(RESTARTING);
         given(service.restart(anyString())).willReturn(testContainer);
 
-        mockMvc.perform(post("/containers/testid0001/restart"))
+        mockMvc.perform(post("/api/v1/containers/testid0001/restart").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("id").value("testid0001"))
                 .andExpect(jsonPath("status").value("RESTARTING"));
     }
 
+    @WithMockUser(username="user")
     @Test
     void remove() throws Exception {
         testContainer.setStatus(REMOVING);
         given(service.remove(anyString())).willReturn(testContainer);
 
-        mockMvc.perform(post("/containers/testid0001/remove"))
+        mockMvc.perform(post("/api/v1/containers/testid0001/remove").with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("id").value("testid0001"))
                 .andExpect(jsonPath("status").value("REMOVING"));
     }
 
+    @WithMockUser(username="user")
     @Test
     void getStatus() throws Exception {
         given(service.findById(anyString())).willReturn(testContainer);
 
-        mockMvc.perform(get("/containers/testid0001"))
+        mockMvc.perform(get("/api/v1/containers/testid0001"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("id").value("testid0001"))
                 .andExpect(jsonPath("status").value("RUNNING"));
     }
 
+    @WithMockUser(username="user")
     @Test
     void list() throws Exception {
         given(service.findRunningContainers()).willReturn(List.of(testContainer, testContainer));
 
-        mockMvc.perform(get("/containers"))
+        mockMvc.perform(get("/api/v1/containers"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.length()").value(2));

--- a/api-server/src/test/java/org/gantry/apiserver/web/HealthCheckControllerTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/web/HealthCheckControllerTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/api-server/src/test/java/org/gantry/apiserver/web/HealthCheckControllerTest.java
+++ b/api-server/src/test/java/org/gantry/apiserver/web/HealthCheckControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,6 +22,7 @@ class HealthCheckControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @WithMockUser
     @Test
     void health() throws Exception {
         mockMvc.perform(get("/health"))


### PR DESCRIPTION
spring security 적용

- /auth/token : 토큰 발급
- 토큰 확인
- 기존 api url에 /api/v1/** 로 변경. 권한 관리 위해
- security 때문에 swagger 접속 불가하여. profile (simple-security) 적용하여 접속 가능하게 처리.


고민할 거리
- refresh token
- 안정적인 secret 관리
- 예외 및 메시지 처리
- token expire 처리 (logout)