### PR TITLE
add duplicateStrategy

### DIFF
--- a/api-server/build.gradle
+++ b/api-server/build.gradle
@@ -48,3 +48,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+tasks.withType(Jar) {
+	duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}


### PR DESCRIPTION
:jar 또는 :bootJar 태스크에서 해당 오류 발생.

한번 빌드되면 그 후에는 잘 되기도 함.

우선은 두 태스크 모두에 duplicateStrategy 적용하는 방식으로 처리